### PR TITLE
Fix release trust checks and rename installed app to The Dictator

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -37,6 +37,13 @@ jobs:
           chmod +x scripts/build-unsigned-release-artifacts.sh scripts/release-preflight.sh
           scripts/build-unsigned-release-artifacts.sh --version "${{ steps.meta.outputs.version }}"
 
+      - name: Verify ad-hoc code signature (release guard)
+        run: |
+          APP_PATH="out/release/build/Build/Products/Release/The Dictator.app"
+          test -d "$APP_PATH"
+          codesign --verify --deep --strict "$APP_PATH"
+          codesign -dv "$APP_PATH" 2>&1 | grep -q "Signature=adhoc"
+
       - name: Upload artifacts to release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -74,7 +81,7 @@ jobs:
               "",
               "If blocked on launch:",
               "1. Move app to `/Applications`",
-              "2. Right-click `the-dictator.app` → **Open**",
+              "2. Right-click `The Dictator.app` → **Open**",
               "3. If needed: **System Settings → Privacy & Security → Open Anyway**",
               "",
               "Full install guide: `docs/install-macos-unsigned.md`",

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -56,6 +56,55 @@ jobs:
             "out/release/the-dictator-${VERSION}-arm64.sha256" \
             --clobber
 
+      - name: Bootstrap release notes from template when body is empty
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+          release_id = str(event["release"]["id"])
+
+          current = subprocess.check_output(
+              [
+                  "gh",
+                  "api",
+                  f"/repos/{os.environ['GITHUB_REPOSITORY']}/releases/{release_id}",
+                  "--jq",
+                  ".body // \"\"",
+              ],
+              text=True,
+          )
+
+          if current.strip():
+              print("Release body already present; skipping template bootstrap")
+              raise SystemExit(0)
+
+          template_path = Path("docs/release-notes-template.md")
+          template = template_path.read_text(encoding="utf-8")
+          body = template.replace("{{VERSION}}", os.environ["VERSION"]).rstrip() + "\n"
+
+          subprocess.run(
+              [
+                  "gh",
+                  "api",
+                  "-X",
+                  "PATCH",
+                  f"/repos/{os.environ['GITHUB_REPOSITORY']}/releases/{release_id}",
+                  "-f",
+                  f"body={body}",
+              ],
+              check=True,
+          )
+
+          print("Release body bootstrapped from docs/release-notes-template.md")
+          PY
+
       - name: Enforce unsigned install warning in release body
         env:
           GH_TOKEN: ${{ github.token }}
@@ -67,9 +116,18 @@ jobs:
           from pathlib import Path
 
           event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
-          release = event["release"]
-          release_id = str(release["id"])
-          body = release.get("body") or ""
+          release_id = str(event["release"]["id"])
+
+          body = subprocess.check_output(
+              [
+                  "gh",
+                  "api",
+                  f"/repos/{os.environ['GITHUB_REPOSITORY']}/releases/{release_id}",
+                  "--jq",
+                  ".body // \"\"",
+              ],
+              text=True,
+          )
 
           marker_start = "<!-- unsigned-macos-warning:start -->"
           marker_end = "<!-- unsigned-macos-warning:end -->"
@@ -108,4 +166,50 @@ jobs:
           )
 
           print("Unsigned warning block appended to release body")
+          PY
+
+      - name: Validate release notes required sections (release guard)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+          release_id = str(event["release"]["id"])
+
+          body = subprocess.check_output(
+              [
+                  "gh",
+                  "api",
+                  f"/repos/{os.environ['GITHUB_REPOSITORY']}/releases/{release_id}",
+                  "--jq",
+                  ".body // \"\"",
+              ],
+              text=True,
+          )
+
+          required_sections = [
+              "## Highlights",
+              "## Fixes",
+              "## Known issues",
+              "## Install",
+              "## Permissions",
+              "<!-- unsigned-macos-warning:start -->",
+              "<!-- unsigned-macos-warning:end -->",
+          ]
+
+          missing = [section for section in required_sections if section not in body]
+          if missing:
+              raise SystemExit(
+                  "Missing required release notes sections/markers: " + ", ".join(missing)
+              )
+
+          if "{{VERSION}}" in body:
+              raise SystemExit("Release body still contains '{{VERSION}}' placeholder")
+
+          print("Release notes guard passed")
           PY

--- a/docs/install-macos-unsigned.md
+++ b/docs/install-macos-unsigned.md
@@ -10,13 +10,13 @@ macOS may warn that the app is from an unidentified developer. This is expected 
    - `the-dictator-<version>-arm64.dmg` (recommended), or
    - `the-dictator-<version>-arm64.zip`
 2. (Optional) Verify checksum using `the-dictator-<version>-arm64.sha256`.
-3. Move `the-dictator.app` to `/Applications`.
+3. Move `The Dictator.app` to `/Applications`.
 4. Launch from `/Applications`.
 
 ## If macOS blocks launch
 
 1. In Finder, go to `/Applications`.
-2. Right-click `the-dictator.app` → **Open**.
+2. Right-click `The Dictator.app` → **Open**.
 3. Click **Open** in the confirmation dialog.
 
 If still blocked:
@@ -27,7 +27,7 @@ If still blocked:
 Advanced fallback:
 
 ```bash
-xattr -dr com.apple.quarantine /Applications/the-dictator.app
+xattr -dr com.apple.quarantine "/Applications/The Dictator.app"
 ```
 
 (Use only if the standard right-click/open flow does not work.)

--- a/docs/model-management-delivery-checklist.md
+++ b/docs/model-management-delivery-checklist.md
@@ -37,8 +37,8 @@
 ## Suggested finish sequence
 1. Bundle artifacts and verify startup detects bundled base model.
    - Fetch base model locally: `scripts/fetch-bundled-base-model.sh`
-   - Optional helper: `scripts/verify-bundled-assets.sh /path/to/the-dictator.app`
-   - Ship preflight: `scripts/release-preflight.sh /path/to/the-dictator.app`
+   - Optional helper: `scripts/verify-bundled-assets.sh /path/to/The\ Dictator.app`
+   - Ship preflight: `scripts/release-preflight.sh /path/to/The\ Dictator.app`
 2. Publish first real manifest + one downloadable non-base model.
 3. Re-run release preflight, then run manual QA matrix and fix any regression.
 4. Freeze UI copy and prepare release build.

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -12,7 +12,7 @@
 ## Install
 1. Download `the-dictator-{{VERSION}}-arm64.dmg` (or ZIP fallback).
 2. Verify checksum file `the-dictator-{{VERSION}}-arm64.sha256`.
-3. Move `the-dictator.app` to `/Applications`.
+3. Move `The Dictator.app` to `/Applications`.
 4. Launch from `/Applications`.
 
 <!-- unsigned-macos-warning:start -->
@@ -20,7 +20,7 @@
 This release is not notarized by Apple. You may see macOS security warnings.
 
 If blocked on launch:
-1. Right-click `the-dictator.app` in `/Applications` → **Open**
+1. Right-click `The Dictator.app` in `/Applications` → **Open**
 2. If needed: **System Settings → Privacy & Security → Open Anyway**
 
 Full install guide: `docs/install-macos-unsigned.md`

--- a/docs/release-runbook-v1.md
+++ b/docs/release-runbook-v1.md
@@ -28,6 +28,13 @@ Before upload, CI must pass a release guard that verifies:
 - `codesign --verify --deep --strict "out/release/build/Build/Products/Release/The Dictator.app"`
 - signature is ad-hoc (`Signature=adhoc`)
 
+## Release notes policy (template + guards)
+
+The release workflow enforces two release-notes behaviors:
+
+1. **Template bootstrap**: if release body is empty, CI fills it from `docs/release-notes-template.md` and substitutes `{{VERSION}}`.
+2. **Required-section guard**: CI fails if release notes are missing required sections/markers (`Highlights`, `Fixes`, `Known issues`, `Install`, `Permissions`, unsigned-warning markers).
+
 ## Required user-warning policy
 
 Each public release must include unsigned macOS warning guidance.

--- a/docs/release-runbook-v1.md
+++ b/docs/release-runbook-v1.md
@@ -8,6 +8,7 @@ Date: 2026-04-24
 - **No Apple Developer Program enrollment**
 - No Developer ID signing
 - No notarization
+- CI applies **ad-hoc code signing** to the app bundle before packaging (required release guard)
 - Users may hit Gatekeeper warnings; install instructions are mandatory
 
 ## Canonical release path
@@ -22,6 +23,10 @@ Workflow builds and uploads:
 - `the-dictator-<version>-arm64.dmg`
 - `the-dictator-<version>-arm64.zip`
 - `the-dictator-<version>-arm64.sha256`
+
+Before upload, CI must pass a release guard that verifies:
+- `codesign --verify --deep --strict "out/release/build/Build/Products/Release/The Dictator.app"`
+- signature is ad-hoc (`Signature=adhoc`)
 
 ## Required user-warning policy
 

--- a/scripts/build-unsigned-release-artifacts.sh
+++ b/scripts/build-unsigned-release-artifacts.sh
@@ -74,7 +74,7 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
-for cmd in xcodebuild create-dmg shasum ditto lipo; do
+for cmd in xcodebuild create-dmg shasum ditto lipo codesign; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "❌ Required command not found: $cmd"
     exit 1
@@ -102,9 +102,10 @@ if [[ ! -f "$PROJECT" ]]; then
   fi
 fi
 
+APP_NAME="The Dictator"
 BUILD_DIR="$OUTPUT_DIR/build"
 APP_BUILD_DIR="$BUILD_DIR/Build/Products/Release"
-APP_PATH="$APP_BUILD_DIR/the-dictator.app"
+APP_PATH="$APP_BUILD_DIR/${APP_NAME}.app"
 DMG_SRC_DIR="$OUTPUT_DIR/dmg-src"
 DMG_PATH="$OUTPUT_DIR/the-dictator-${VERSION}-${ARCH}.dmg"
 ZIP_PATH="$OUTPUT_DIR/the-dictator-${VERSION}-${ARCH}.zip"
@@ -138,6 +139,11 @@ fi
 
 echo "✅ App binary architecture: $ARCHS"
 
+echo "==> Applying ad-hoc signature (non-notarized)"
+codesign --force --sign - --timestamp=none --deep "$APP_PATH"
+codesign --verify --deep --strict "$APP_PATH"
+echo "✅ Ad-hoc signature verified"
+
 echo "==> Running release bundle preflight"
 if [[ -n "$MANIFEST_URL" ]]; then
   scripts/release-preflight.sh "$APP_PATH" "$MANIFEST_URL"
@@ -149,10 +155,10 @@ cp -R "$APP_PATH" "$DMG_SRC_DIR/"
 
 echo "==> Creating DMG"
 create-dmg \
-  --volname "the-dictator" \
+  --volname "$APP_NAME" \
   --window-size 600 400 \
   --icon-size 100 \
-  --icon "the-dictator.app" 175 190 \
+  --icon "${APP_NAME}.app" 175 190 \
   --app-drop-link 425 190 \
   "$DMG_PATH" \
   "$DMG_SRC_DIR"

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -5,7 +5,7 @@ APP_PATH="${1:-}"
 MANIFEST_OVERRIDE="${2:-}"
 
 if [[ -z "$APP_PATH" ]]; then
-  echo "Usage: $0 /path/to/the-dictator.app [manifest-url-override]"
+  echo "Usage: $0 /path/to/The\ Dictator.app [manifest-url-override]"
   exit 1
 fi
 
@@ -34,6 +34,12 @@ check_fail() {
 }
 
 echo "Release preflight for: $APP_PATH"
+
+if codesign --verify --deep --strict "$APP_PATH" >/dev/null 2>&1; then
+  check_ok "Code signature verifies."
+else
+  check_fail "Code signature verification failed."
+fi
 
 if [[ -f "$PLACEHOLDER_CLI" || -f "$PLACEHOLDER_MODEL" ]]; then
   check_fail "Placeholder marker files are still present in bundle resources."

--- a/scripts/verify-bundled-assets.sh
+++ b/scripts/verify-bundled-assets.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 APP_PATH="${1:-}"
 if [[ -z "$APP_PATH" ]]; then
-  echo "Usage: $0 /path/to/the-dictator.app"
+  echo "Usage: $0 /path/to/The\ Dictator.app"
   exit 1
 fi
 

--- a/the-dictator/the-dictator.xcodeproj/project.pbxproj
+++ b/the-dictator/the-dictator.xcodeproj/project.pbxproj
@@ -301,7 +301,10 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "captainDuckay.the-dictator";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "The Dictator";
+				EXECUTABLE_NAME = "the-dictator";
+				INFOPLIST_KEY_CFBundleDisplayName = "The Dictator";
+				INFOPLIST_KEY_CFBundleName = "The Dictator";
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -338,7 +341,10 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "captainDuckay.the-dictator";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "The Dictator";
+				EXECUTABLE_NAME = "the-dictator";
+				INFOPLIST_KEY_CFBundleDisplayName = "The Dictator";
+				INFOPLIST_KEY_CFBundleName = "The Dictator";
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;


### PR DESCRIPTION
## Summary
- rename product bundle to `The Dictator.app` while keeping executable name stable (`the-dictator`)
- add ad-hoc signing in release artifact build script and verify signature
- add release guard in GitHub Actions to enforce ad-hoc signature before upload
- update release/install docs and templates to reference `The Dictator.app`

## Why
Recent release artifacts could be flagged as damaged due to packaging/signing trust issues. This ensures the app bundle is consistently ad-hoc signed and verified in CI before publishing.

## Validation
- local `xcodebuild` release build succeeds
- `scripts/build-unsigned-release-artifacts.sh --version 1.0.1 --output-dir /tmp/the-dictator-release-test` succeeds
- confirmed ZIP contains `The Dictator.app`
- verified signature checks pass in preflight
