### PR TITLE
Deepen architecture seams + add CI seam tests

### DIFF
--- a/.github/workflows/architecture-seams.yml
+++ b/.github/workflows/architecture-seams.yml
@@ -1,0 +1,20 @@
+name: Architecture Seam Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  seam-tests:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run architecture seam tests
+        run: |
+          chmod +x scripts/test-architecture-seams.sh
+          scripts/test-architecture-seams.sh

--- a/scripts/test-architecture-seams.sh
+++ b/scripts/test-architecture-seams.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+BIN="$(mktemp -t architecture-seams-tests)"
+
+swiftc \
+  scripts/tests/architecture_seams_tests.swift \
+  the-dictator/the-dictator/Core/AppSettingsInterfaces.swift \
+  the-dictator/the-dictator/Core/ModelManagerModule.swift \
+  the-dictator/the-dictator/Models/WhisperModelCatalog.swift \
+  the-dictator/the-dictator/Services/AppLogger.swift \
+  the-dictator/the-dictator/Services/ModelCatalogService.swift \
+  the-dictator/the-dictator/Services/ModelDownloadService.swift \
+  the-dictator/the-dictator/Services/ModelIntegrityService.swift \
+  the-dictator/the-dictator/Services/ModelStoreService.swift \
+  the-dictator/the-dictator/Services/RuntimeReadinessService.swift \
+  -o "$BIN"
+
+"$BIN"
+rm -f "$BIN"

--- a/scripts/tests/architecture_seams_tests.swift
+++ b/scripts/tests/architecture_seams_tests.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+struct AppSettings {
+    var selectedModelID: String = "base"
+    var useCustomModelPath: Bool = false
+    var customModelPath: String = ""
+}
+
+@MainActor
+final class InMemorySettingsProvider: ModelManagerSettingsProviding {
+    var currentSettings: AppSettings
+
+    init(currentSettings: AppSettings) {
+        self.currentSettings = currentSettings
+    }
+
+    func update(_ mutate: (inout AppSettings) -> Void) {
+        var next = currentSettings
+        mutate(&next)
+        currentSettings = next
+    }
+}
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            fatalError("MockURLProtocol.requestHandler not set")
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+enum TestFailure: Error {
+    case failed(String)
+}
+
+func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    if !condition() {
+        throw TestFailure.failed(message)
+    }
+}
+
+func assertContains(_ value: String?, _ expectedSubstring: String, _ message: String) throws {
+    guard let value, value.contains(expectedSubstring) else {
+        throw TestFailure.failed("\(message). value=\(value ?? "nil")")
+    }
+}
+
+@MainActor
+func waitUntil(timeoutSeconds: TimeInterval = 2.0, _ predicate: @escaping () -> Bool) async throws {
+    let start = Date()
+    while !predicate() {
+        if Date().timeIntervalSince(start) > timeoutSeconds {
+            throw TestFailure.failed("Timed out waiting for async predicate")
+        }
+        try await Task.sleep(nanoseconds: 20_000_000)
+    }
+}
+
+@MainActor
+func testModelManagerModuleSnapshotAndRecovery() async throws {
+    let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent("the-dictator-seam-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+    let bundledModelURL = tempRoot.appendingPathComponent("base.bin", isDirectory: false)
+    try Data("base-model".utf8).write(to: bundledModelURL)
+
+    let modelStoreService = ModelStoreService()
+    try modelStoreService.registerBundledModel(modelID: "base", version: "1.0.0", fileURL: bundledModelURL)
+
+    let manifestURL = URL(string: "https://example.com/manifest.json")!
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let manifestJSON = """
+    {
+      "schemaVersion": 1,
+      "models": [
+        {
+          "id": "base",
+          "level": "base",
+          "displayName": "Balanced",
+          "technicalName": "base",
+          "diskBytes": 142000000,
+          "estimatedRamBytes": 500000000,
+          "downloadURL": null,
+          "sha256": "",
+          "version": "2.0.0",
+          "bundled": true,
+          "minAppVersion": "0.0.0",
+          "maxAppVersion": null
+        },
+        {
+          "id": "small",
+          "level": "small",
+          "displayName": "Higher Accuracy",
+          "technicalName": "small",
+          "diskBytes": 488000000,
+          "estimatedRamBytes": 1300000000,
+          "downloadURL": "https://example.com/small.bin",
+          "sha256": "abc",
+          "version": "1.0.0",
+          "bundled": false,
+          "minAppVersion": "0.0.0",
+          "maxAppVersion": null
+        }
+      ]
+    }
+    """
+
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (response, Data(manifestJSON.utf8))
+    }
+
+    let catalogService = ModelCatalogService(manifestURL: manifestURL, session: session)
+    let settings = InMemorySettingsProvider(currentSettings: AppSettings(selectedModelID: "zz-missing", useCustomModelPath: false, customModelPath: ""))
+
+    let module = ModelManagerModule(
+        settingsProvider: settings,
+        modelStoreService: modelStoreService,
+        modelCatalogService: catalogService,
+        modelDownloadService: ModelDownloadService(),
+        modelIntegrityService: ModelIntegrityService()
+    )
+
+    try await waitUntil {
+        !module.snapshot.isRefreshingCatalog && !module.snapshot.availableModels.isEmpty
+    }
+
+    try assertTrue(module.snapshot.availableModels.count == 2, "Model catalog should expose two compatible models")
+    try assertTrue(module.snapshot.updateAvailableModelIDs.contains("base"), "Base should be flagged as update available")
+    try assertTrue(module.runtimeRecoveryActionTitle == "Use bundled base model", "Recovery action should prefer bundled base model")
+}
+
+@MainActor
+func testRuntimeReadinessServiceIssues() throws {
+    let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent("the-dictator-readiness-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+    let installedModelURL = tempRoot.appendingPathComponent("base.bin")
+    try Data("installed".utf8).write(to: installedModelURL)
+
+    let store = ModelStoreService()
+    try store.registerBundledModel(modelID: "base", version: "1.0.0", fileURL: installedModelURL)
+
+    let missingCustomPath = tempRoot.appendingPathComponent("missing-custom.bin").path
+    let readiness = RuntimeReadinessService(
+        modelStoreService: store,
+        fileExists: { path in
+            if path == missingCustomPath { return false }
+            return FileManager.default.fileExists(atPath: path)
+        },
+        executableExists: { _ in true },
+        pathProvider: { "" }
+    )
+
+    let customMissing = AppSettings(selectedModelID: "base", useCustomModelPath: true, customModelPath: missingCustomPath)
+    try assertContains(
+        readiness.runtimeIssue(for: customMissing),
+        "Custom model file is unavailable",
+        "Expected custom path issue"
+    )
+
+    let notInstalled = AppSettings(selectedModelID: "zz-missing-model", useCustomModelPath: false, customModelPath: "")
+    try assertContains(
+        readiness.runtimeIssue(for: notInstalled),
+        "Selected model zz-missing-model is not installed",
+        "Expected missing selected model issue"
+    )
+
+    let installed = AppSettings(selectedModelID: "base", useCustomModelPath: false, customModelPath: "")
+    try assertTrue(readiness.runtimeIssue(for: installed) == nil, "Expected nil runtime issue when executable + selected model are available")
+}
+
+@main
+struct ArchitectureSeamTests {
+    static func main() async {
+        do {
+            try await testModelManagerModuleSnapshotAndRecovery()
+            try testRuntimeReadinessServiceIssues()
+            print("✅ Architecture seam tests passed")
+        } catch {
+            print("❌ Architecture seam tests failed: \(error)")
+            exit(1)
+        }
+    }
+}

--- a/the-dictator/the-dictator/Core/AppModel.swift
+++ b/the-dictator/the-dictator/Core/AppModel.swift
@@ -13,7 +13,7 @@ struct AudioInputOption: Identifiable, Equatable {
 final class AppModel: ObservableObject {
     // Naming convention:
     // - `workflow*` fields are mirrored from DictationWorkflow snapshot/output.
-    // - `modelManager*` fields belong to model catalog/install/download UI state.
+    // - `modelManager*` fields are mirrored from ModelManagerModule snapshot/output.
     // This keeps ownership explicit at the seam and avoids mixed authorities.
     @Published private(set) var workflowSnapshotState: AppWorkflowState = .idle {
         didSet {
@@ -38,10 +38,6 @@ final class AppModel: ObservableObject {
     @Published private(set) var modelManagerCatalogNextRetryAt: Date?
     @Published private(set) var modelManagerIsRefreshingCatalog: Bool = false
 
-    private var isUsingFallbackModelCatalog: Bool = false
-    private var modelCatalogConsecutiveFailures: Int = 0
-    private var activeModelCatalogRefreshTask: Task<Void, Never>?
-
     let settingsStore: SettingsStore
     let sessionStore: SessionStore
 
@@ -52,88 +48,11 @@ final class AppModel: ObservableObject {
     private let transcriptionService: TranscriptionService
     private let permissionsService: PermissionsService
     private let escapeMonitorService: EscapeMonitorService
-    private let modelStoreService: ModelStoreService
-    private let modelCatalogService: ModelCatalogService
-    private let modelDownloadService: ModelDownloadService
-    private let modelIntegrityService: ModelIntegrityService
     private let dictationWorkflow: DictationWorkflow
+    private let modelManager: ModelManagerModule
 
     private var cancellables = Set<AnyCancellable>()
-    private var installedModelRecordsByID: [String: InstalledModelRecord] = [:]
     private var visibleSettingsWindowCount: Int = 0
-
-    private static let fallbackModelCatalog: [ManagedModelDescriptor] = [
-        ManagedModelDescriptor(
-            id: "tiny",
-            level: .tiny,
-            displayName: "Fastest",
-            technicalName: "tiny",
-            diskBytes: 78_000_000,
-            estimatedRamBytes: 350_000_000,
-            downloadURL: nil,
-            sha256: "",
-            version: "fallback",
-            bundled: false,
-            minAppVersion: "0.0.0",
-            maxAppVersion: nil
-        ),
-        ManagedModelDescriptor(
-            id: "base",
-            level: .base,
-            displayName: "Balanced",
-            technicalName: "base",
-            diskBytes: 142_000_000,
-            estimatedRamBytes: 500_000_000,
-            downloadURL: nil,
-            sha256: "",
-            version: "fallback",
-            bundled: true,
-            minAppVersion: "0.0.0",
-            maxAppVersion: nil
-        ),
-        ManagedModelDescriptor(
-            id: "small",
-            level: .small,
-            displayName: "Higher Accuracy",
-            technicalName: "small",
-            diskBytes: 488_000_000,
-            estimatedRamBytes: 1_300_000_000,
-            downloadURL: nil,
-            sha256: "",
-            version: "fallback",
-            bundled: false,
-            minAppVersion: "0.0.0",
-            maxAppVersion: nil
-        ),
-        ManagedModelDescriptor(
-            id: "medium",
-            level: .medium,
-            displayName: "High Accuracy",
-            technicalName: "medium",
-            diskBytes: 1_530_000_000,
-            estimatedRamBytes: 3_500_000_000,
-            downloadURL: nil,
-            sha256: "",
-            version: "fallback",
-            bundled: false,
-            minAppVersion: "0.0.0",
-            maxAppVersion: nil
-        ),
-        ManagedModelDescriptor(
-            id: "large",
-            level: .large,
-            displayName: "Best Accuracy",
-            technicalName: "large",
-            diskBytes: 3_100_000_000,
-            estimatedRamBytes: 6_500_000_000,
-            downloadURL: nil,
-            sha256: "",
-            version: "fallback",
-            bundled: false,
-            minAppVersion: "0.0.0",
-            maxAppVersion: nil
-        ),
-    ]
 
     init(
         settingsStore: SettingsStore,
@@ -152,7 +71,8 @@ final class AppModel: ObservableObject {
         modelStoreService: ModelStoreService,
         modelCatalogService: ModelCatalogService,
         modelDownloadService: ModelDownloadService,
-        modelIntegrityService: ModelIntegrityService
+        modelIntegrityService: ModelIntegrityService,
+        runtimeReadinessService: DictationRuntimeReadinessProviding
     ) {
         self.settingsStore = settingsStore
         self.sessionStore = sessionStore
@@ -163,12 +83,17 @@ final class AppModel: ObservableObject {
         self.transcriptionService = transcriptionService
         self.permissionsService = permissionsService
         self.escapeMonitorService = escapeMonitorService
-        self.modelStoreService = modelStoreService
-        self.modelCatalogService = modelCatalogService
-        self.modelDownloadService = modelDownloadService
-        self.modelIntegrityService = modelIntegrityService
+
+        self.modelManager = ModelManagerModule(
+            settingsProvider: settingsStore,
+            modelStoreService: modelStoreService,
+            modelCatalogService: modelCatalogService,
+            modelDownloadService: modelDownloadService,
+            modelIntegrityService: modelIntegrityService
+        )
+
         self.dictationWorkflow = DictationWorkflow(
-            settingsStore: settingsStore,
+            settingsProvider: settingsStore,
             sessionStore: sessionStore,
             audioCaptureService: audioCaptureService,
             audioInputDeviceService: audioInputDeviceService,
@@ -177,19 +102,18 @@ final class AppModel: ObservableObject {
             textInsertionService: textInsertionService,
             permissionsService: permissionsService,
             latencyTracker: latencyTracker,
-            modelStoreService: modelStoreService,
+            runtimeReadinessProvider: runtimeReadinessService,
             notificationService: notificationService
         )
 
-        self.modelDownloadService.onStateChange = { [weak self] modelID, state in
-            Task { @MainActor in
-                self?.modelManagerDownloadStates[modelID] = state
-            }
+        self.modelManager.onInventoryChanged = { [weak self] in
+            self?.dictationWorkflow.refreshRuntimeReadiness()
         }
 
         notificationService.requestAuthorizationIfNeeded()
         permissionsService.runFirstLaunchChecksIfNeeded(notificationService: notificationService)
         bindDictationWorkflow()
+        bindModelManager()
         setupHotkeyCallbacks()
         bindSettings()
         registerPushToTalkHotkey()
@@ -197,9 +121,7 @@ final class AppModel: ObservableObject {
         refreshPermissionStatuses()
         refreshBackendCapabilitiesDescription()
         refreshAudioInputState()
-        registerBundledBaseModelIfAvailable()
-        refreshInstalledModels()
-        refreshModelCatalog()
+        applyModelManagerSnapshot(modelManager.snapshot)
         dictationWorkflow.refreshRuntimeReadiness(notifyIfNeeded: false)
     }
 
@@ -221,6 +143,7 @@ final class AppModel: ObservableObject {
         let modelCatalogService = ModelCatalogService(manifestURL: AppConfiguration.modelManifestURL)
         let modelDownloadService = ModelDownloadService()
         let modelIntegrityService = ModelIntegrityService()
+        let runtimeReadinessService = RuntimeReadinessService(modelStoreService: modelStoreService)
 
         self.init(
             settingsStore: settingsStore,
@@ -239,7 +162,8 @@ final class AppModel: ObservableObject {
             modelStoreService: modelStoreService,
             modelCatalogService: modelCatalogService,
             modelDownloadService: modelDownloadService,
-            modelIntegrityService: modelIntegrityService
+            modelIntegrityService: modelIntegrityService,
+            runtimeReadinessService: runtimeReadinessService
         )
 
         if hotkeyService == nil {
@@ -328,6 +252,25 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private func bindModelManager() {
+        modelManager.$snapshot
+            .sink { [weak self] snapshot in
+                self?.applyModelManagerSnapshot(snapshot)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func applyModelManagerSnapshot(_ snapshot: ModelManagerSnapshot) {
+        modelManagerAvailableModels = snapshot.availableModels
+        installedModelIDs = snapshot.installedModelIDs
+        modelManagerDownloadStates = snapshot.downloadStates
+        updateAvailableModelIDs = snapshot.updateAvailableModelIDs
+        modelManagerStatusMessage = snapshot.statusMessage
+        modelManagerCatalogLastRefreshedAt = snapshot.catalogLastRefreshedAt
+        modelManagerCatalogNextRetryAt = snapshot.catalogNextRetryAt
+        modelManagerIsRefreshingCatalog = snapshot.isRefreshingCatalog
+    }
+
     func requestMicrophonePermission() {
         Task { @MainActor in
             let granted = await permissionsService.requestMicrophonePermissionForRecording(notificationService: notificationService)
@@ -387,309 +330,80 @@ final class AppModel: ObservableObject {
     }
 
     func refreshModelCatalog(force: Bool = false) {
-        if activeModelCatalogRefreshTask != nil {
-            return
-        }
-
-        if !force, let nextRetryAt = modelManagerCatalogNextRetryAt, Date() < nextRetryAt {
-            let remaining = max(Int(nextRetryAt.timeIntervalSinceNow.rounded()), 1)
-            modelManagerStatusMessage = "Model catalog retry scheduled in \(remaining)s."
-            return
-        }
-
-        modelManagerIsRefreshingCatalog = true
-        activeModelCatalogRefreshTask = Task { @MainActor in
-            defer {
-                activeModelCatalogRefreshTask = nil
-                modelManagerIsRefreshingCatalog = false
-            }
-
-            do {
-                let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-                let manifest = try await modelCatalogService.fetchManifest()
-                let compatible = modelCatalogService.compatibleModels(from: manifest, appVersion: appVersion)
-                modelManagerAvailableModels = compatible.sorted { $0.diskBytes < $1.diskBytes }
-                isUsingFallbackModelCatalog = false
-                modelCatalogConsecutiveFailures = 0
-                modelManagerCatalogNextRetryAt = nil
-                modelManagerCatalogLastRefreshedAt = Date()
-                modelManagerStatusMessage = compatible.isEmpty ? "No compatible models available for this app version." : nil
-            } catch {
-                modelManagerAvailableModels = Self.fallbackModelCatalog
-                isUsingFallbackModelCatalog = true
-                modelCatalogConsecutiveFailures += 1
-                let retryDelay = Self.catalogRetryDelaySeconds(failureCount: modelCatalogConsecutiveFailures)
-                modelManagerCatalogNextRetryAt = Date().addingTimeInterval(retryDelay)
-                modelManagerStatusMessage = "Unable to load online model catalog. Showing local fallback metadata."
-            }
-
-            refreshInstalledModels()
-        }
+        modelManager.refreshModelCatalog(force: force)
     }
 
     func refreshInstalledModels() {
-        let installedRecords = modelStoreService.allInstalled()
-        installedModelIDs = Set(installedRecords.map(\.modelID))
-        installedModelRecordsByID = Dictionary(uniqueKeysWithValues: installedRecords.map { ($0.modelID, $0) })
-
-        let updates = modelManagerAvailableModels.compactMap { descriptor -> String? in
-            guard let installed = installedModelRecordsByID[descriptor.id] else {
-                return nil
-            }
-            if isUsingFallbackModelCatalog {
-                return nil
-            }
-            return installed.version != descriptor.version ? descriptor.id : nil
-        }
-        updateAvailableModelIDs = Set(updates)
-        dictationWorkflow.refreshRuntimeReadiness()
+        modelManager.refreshInstalledModels()
     }
 
     func isModelInstalled(_ modelID: String) -> Bool {
-        installedModelIDs.contains(modelID)
+        modelManager.isModelInstalled(modelID)
     }
 
     func isModelUpdateAvailable(_ modelID: String) -> Bool {
-        updateAvailableModelIDs.contains(modelID)
+        modelManager.isModelUpdateAvailable(modelID)
     }
 
     func selectModel(id: String) {
-        settingsStore.update { settings in
-            settings.selectedModelID = id
-            settings.useCustomModelPath = false
-        }
+        modelManager.selectModel(id: id)
     }
 
     func performRuntimeRecoveryAction() {
-        let previousModelID = settingsStore.settings.selectedModelID
-        guard let recoveryModelID = runtimeRecoveryTargetModelID else {
-            return
-        }
-
-        AppLogger.info(
-            AppLogger.settings,
-            "Runtime recovery action: switching model from \(previousModelID) to \(recoveryModelID)."
-        )
-
-        selectModel(id: recoveryModelID)
-        if recoveryModelID == "base" {
-            modelManagerStatusMessage = "Switched to bundled base model."
-        } else {
-            modelManagerStatusMessage = "Switched to installed model: \(recoveryModelID)."
-        }
+        modelManager.performRuntimeRecoveryAction()
         dictationWorkflow.refreshRuntimeReadiness(notifyIfNeeded: false)
     }
 
     func downloadModel(id: String) {
-        guard let descriptor = modelManagerAvailableModels.first(where: { $0.id == id }) else {
-            modelManagerStatusMessage = "Unknown model selection: \(id)."
-            return
-        }
-
-        Task { @MainActor in
-            modelManagerDownloadStates[id] = .downloading(progress: 0)
-
-            do {
-                let tempURL = try await modelDownloadService.startDownload(descriptor)
-                let expectedHash = descriptor.sha256.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !expectedHash.isEmpty {
-                    try modelIntegrityService.verifySHA256(fileURL: tempURL, expectedHex: expectedHash)
-                }
-                _ = try modelStoreService.install(tempFileURL: tempURL, descriptor: descriptor)
-                refreshInstalledModels()
-                modelManagerDownloadStates[id] = .completed(tempFilePath: tempURL.path)
-                modelManagerStatusMessage = "Installed \(descriptor.displayName) (\(descriptor.technicalName))."
-            } catch {
-                if let downloadError = error as? ModelDownloadError, case .cancelled = downloadError {
-                    modelManagerDownloadStates[id] = .idle
-                    modelManagerStatusMessage = "Download cancelled for \(descriptor.displayName)."
-                    return
-                }
-
-                let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-                let visibleMessage = message.isEmpty ? "Unknown error" : message
-                modelManagerDownloadStates[id] = .failed(message: visibleMessage)
-                modelManagerStatusMessage = "Failed to install \(descriptor.displayName): \(visibleMessage)"
-                AppLogger.error(AppLogger.settings, "Model install failed for \(descriptor.id): \(visibleMessage)")
-            }
-        }
+        modelManager.downloadModel(id: id)
     }
 
     func cancelModelDownload(id: String) {
-        modelDownloadService.cancelDownload(modelID: id)
-        modelManagerDownloadStates[id] = .idle
+        modelManager.cancelModelDownload(id: id)
     }
 
     func deleteModel(id: String) {
-        guard canDeleteModel(id) else {
-            modelManagerStatusMessage = "\(id) is bundled with the app and cannot be deleted."
-            return
-        }
-
-        do {
-            try modelStoreService.delete(modelID: id)
-            refreshInstalledModels()
-            modelManagerDownloadStates[id] = .idle
-            modelManagerStatusMessage = "Deleted model \(id)."
-        } catch {
-            modelManagerStatusMessage = "Failed to delete model \(id): \(error.localizedDescription)"
-        }
+        modelManager.deleteModel(id: id)
     }
 
     func modelLabel(for descriptor: ManagedModelDescriptor) -> String {
-        "\(descriptor.displayName) (\(descriptor.technicalName))"
+        modelManager.modelLabel(for: descriptor)
     }
 
     func modelResourceHint(for descriptor: ManagedModelDescriptor) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useMB, .useGB]
-        formatter.countStyle = .file
-        let disk = formatter.string(fromByteCount: descriptor.diskBytes)
-        let ram = formatter.string(fromByteCount: descriptor.estimatedRamBytes)
-        return "Disk: \(disk) • Est. RAM: \(ram)"
+        modelManager.modelResourceHint(for: descriptor)
     }
 
     func modelVersionHint(for descriptor: ManagedModelDescriptor) -> String {
-        let available = descriptor.version
-        if let installed = installedModelRecordsByID[descriptor.id]?.version {
-            return installed == available ? "Version: \(available)" : "Installed: \(installed) • Available: \(available)"
-        }
-        return "Available version: \(available)"
+        modelManager.modelVersionHint(for: descriptor)
     }
 
     func isBundledModel(_ modelID: String) -> Bool {
-        modelManagerAvailableModels.first(where: { $0.id == modelID })?.bundled ?? false
+        modelManager.isBundledModel(modelID)
     }
 
     func canDeleteModel(_ modelID: String) -> Bool {
-        isModelInstalled(modelID) && !isBundledModel(modelID)
+        modelManager.canDeleteModel(modelID)
     }
 
     var isUsingFallbackCatalog: Bool {
-        isUsingFallbackModelCatalog
+        modelManager.snapshot.isUsingFallbackCatalog
     }
 
     var modelManagerCatalogRefreshDescription: String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .short
-
-        let refreshedText: String
-        if let refreshedAt = modelManagerCatalogLastRefreshedAt {
-            refreshedText = "Last refresh \(formatter.localizedString(for: refreshedAt, relativeTo: Date()))"
-        } else {
-            refreshedText = "Catalog not refreshed yet"
-        }
-
-        if let retryAt = modelManagerCatalogNextRetryAt, Date() < retryAt {
-            return "\(refreshedText) • Retry \(formatter.localizedString(for: retryAt, relativeTo: Date()))"
-        }
-
-        return refreshedText
+        modelManager.catalogRefreshDescription()
     }
 
     var modelManagerOnboardingHint: String? {
-        if isModelInstalled("base") {
-            return "Balanced (base) is bundled and ready for offline dictation."
-        }
-
-        return "No bundled base model detected. Download a model to start dictation."
+        modelManager.onboardingHint
     }
 
     var runtimeRecoveryActionTitle: String? {
-        guard let recoveryModelID = runtimeRecoveryTargetModelID else {
-            return nil
-        }
-
-        if recoveryModelID == "base" {
-            return "Use bundled base model"
-        }
-
-        return "Use installed model (\(recoveryModelID))"
-    }
-
-    private var runtimeRecoveryTargetModelID: String? {
-        let settings = settingsStore.settings
-        guard !settings.useCustomModelPath else {
-            return nil
-        }
-
-        let selected = settings.selectedModelID
-        guard !isModelInstalled(selected) else {
-            return nil
-        }
-
-        if selected != "base", isModelInstalled("base") {
-            return "base"
-        }
-
-        if let preferredInstalled = modelManagerAvailableModels
-            .map(\.id)
-            .first(where: { $0 != selected && isModelInstalled($0) }) {
-            return preferredInstalled
-        }
-
-        return installedModelIDs
-            .sorted()
-            .first(where: { $0 != selected })
+        modelManager.runtimeRecoveryActionTitle
     }
 
     func modelStatus(for modelID: String) -> String {
-        if case .downloading(let progress) = modelManagerDownloadStates[modelID] {
-            return "Downloading \(Int(progress * 100))%"
-        }
-
-        if case .failed = modelManagerDownloadStates[modelID] {
-            return "Failed"
-        }
-
-        if settingsStore.settings.selectedModelID == modelID && !settingsStore.settings.useCustomModelPath {
-            if isModelInstalled(modelID) {
-                return isModelUpdateAvailable(modelID) ? "Active • Update available" : "Active"
-            }
-            return "Selected (not installed)"
-        }
-
-        if isModelInstalled(modelID) {
-            if isBundledModel(modelID) {
-                return isModelUpdateAvailable(modelID) ? "Bundled • Update available" : "Bundled"
-            }
-            return isModelUpdateAvailable(modelID) ? "Installed • Update available" : "Installed"
-        }
-
-        return "Not installed"
-    }
-
-    private func registerBundledBaseModelIfAvailable() {
-        guard let bundledModelURL = bundledBaseModelURL() else {
-            return
-        }
-
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-        do {
-            try modelStoreService.registerBundledModel(modelID: "base", version: appVersion, fileURL: bundledModelURL)
-        } catch {
-            AppLogger.error(AppLogger.settings, "Failed to register bundled base model: \(error.localizedDescription)")
-        }
-    }
-
-    private func bundledBaseModelURL() -> URL? {
-        guard let resourceURL = Bundle.main.resourceURL else {
-            return nil
-        }
-
-        let candidates = [
-            resourceURL.appendingPathComponent("models/base/model.bin", isDirectory: false),
-            resourceURL.appendingPathComponent("models/base.bin", isDirectory: false),
-            resourceURL.appendingPathComponent("base.bin", isDirectory: false),
-        ]
-
-        return candidates.first(where: { FileManager.default.fileExists(atPath: $0.path) })
-    }
-
-    private static func catalogRetryDelaySeconds(failureCount: Int) -> TimeInterval {
-        let schedule: [TimeInterval] = [5, 15, 30, 60, 120, 300]
-        let index = min(max(failureCount - 1, 0), schedule.count - 1)
-        return schedule[index]
+        modelManager.modelStatus(for: modelID)
     }
 
     private func setupEscapeMonitoring() {
@@ -851,5 +565,4 @@ final class AppModel: ObservableObject {
             }
         }
     }
-
 }

--- a/the-dictator/the-dictator/Core/AppSettingsInterfaces.swift
+++ b/the-dictator/the-dictator/Core/AppSettingsInterfaces.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@MainActor
+protocol DictationSettingsProviding: AnyObject {
+    var currentSettings: AppSettings { get }
+}
+
+@MainActor
+protocol ModelManagerSettingsProviding: DictationSettingsProviding {
+    func update(_ mutate: (inout AppSettings) -> Void)
+}

--- a/the-dictator/the-dictator/Core/AppWorkflow.swift
+++ b/the-dictator/the-dictator/Core/AppWorkflow.swift
@@ -122,7 +122,7 @@ final class DictationWorkflow: ObservableObject {
 
     var onOutcome: ((DictationWorkflowOutcome) -> Void)?
 
-    private let settingsStore: SettingsStore
+    private let settingsProvider: DictationSettingsProviding
     private let sessionStore: SessionStore
     private let audioCaptureService: AudioCaptureService
     private let audioInputDeviceService: AudioInputDeviceService
@@ -131,7 +131,7 @@ final class DictationWorkflow: ObservableObject {
     private let textInsertionService: TextInsertionService
     private let permissionsService: PermissionsService
     private let latencyTracker: LatencyTracker
-    private let modelStoreService: ModelStoreService
+    private let runtimeReadinessProvider: DictationRuntimeReadinessProviding
     private let notificationService: NotificationService
 
     private var recordingStartedAt: Date?
@@ -148,7 +148,7 @@ final class DictationWorkflow: ObservableObject {
     }
 
     init(
-        settingsStore: SettingsStore,
+        settingsProvider: DictationSettingsProviding,
         sessionStore: SessionStore,
         audioCaptureService: AudioCaptureService,
         audioInputDeviceService: AudioInputDeviceService,
@@ -157,10 +157,10 @@ final class DictationWorkflow: ObservableObject {
         textInsertionService: TextInsertionService,
         permissionsService: PermissionsService,
         latencyTracker: LatencyTracker,
-        modelStoreService: ModelStoreService,
+        runtimeReadinessProvider: DictationRuntimeReadinessProviding,
         notificationService: NotificationService
     ) {
-        self.settingsStore = settingsStore
+        self.settingsProvider = settingsProvider
         self.sessionStore = sessionStore
         self.audioCaptureService = audioCaptureService
         self.audioInputDeviceService = audioInputDeviceService
@@ -169,7 +169,7 @@ final class DictationWorkflow: ObservableObject {
         self.textInsertionService = textInsertionService
         self.permissionsService = permissionsService
         self.latencyTracker = latencyTracker
-        self.modelStoreService = modelStoreService
+        self.runtimeReadinessProvider = runtimeReadinessProvider
         self.notificationService = notificationService
     }
 
@@ -178,25 +178,10 @@ final class DictationWorkflow: ObservableObject {
     }
 
     func refreshRuntimeReadiness(notifyIfNeeded: Bool = true) {
-        updateModelRuntimePreflightDescription()
+        snapshot.modelRuntimePreflightDescription = runtimeReadinessProvider.modelRuntimePreflightDescription()
 
-        let settings = settingsStore.settings
-
-        let issue: String?
-        if !hasUsableWhisperExecutable() {
-            issue = "Transcription engine is unavailable. Reinstall the app or add whisper-cli to PATH."
-        } else if settings.useCustomModelPath {
-            if settings.customModelPath.isEmpty || !FileManager.default.fileExists(atPath: settings.customModelPath) {
-                issue = "Custom model file is unavailable. Choose a valid model file in Settings → Transcription."
-            } else {
-                issue = nil
-            }
-        } else if modelStoreService.localPath(for: settings.selectedModelID) == nil {
-            issue = "Selected model \(settings.selectedModelID) is not installed. Open Settings → Transcription and download it in Model Manager."
-        } else {
-            issue = nil
-        }
-
+        let settings = settingsProvider.currentSettings
+        let issue = runtimeReadinessProvider.runtimeIssue(for: settings)
         snapshot.runtimeIssue = issue
 
         guard notifyIfNeeded else {
@@ -238,7 +223,7 @@ final class DictationWorkflow: ObservableObject {
             activeSessionID = UUID()
             apply(.hotkeyDown(permissionsOK: true))
             updateRouteNotifications(for: captureRoute.routingState)
-            audioCueService.playRecordingStarted(enabled: settingsStore.settings.audioCuesEnabled)
+            audioCueService.playRecordingStarted(enabled: settingsProvider.currentSettings.audioCuesEnabled)
         } catch {
             AppLogger.error(AppLogger.app, "Failed to start audio capture: \(error.localizedDescription)")
             onOutcome?(.notification("Couldn’t start recording with current microphone. Try reconnecting or choose another input in Settings."))
@@ -254,7 +239,7 @@ final class DictationWorkflow: ObservableObject {
 
         let durationMS = Int((Date().timeIntervalSince(recordingStartedAt ?? Date())) * 1_000)
         recordingStartedAt = nil
-        audioCueService.playRecordingStopped(enabled: settingsStore.settings.audioCuesEnabled)
+        audioCueService.playRecordingStopped(enabled: settingsProvider.currentSettings.audioCuesEnabled)
 
         if durationMS < AppStateMachine.minimumHoldDurationMS {
             audioCaptureService.discardCapture()
@@ -316,7 +301,7 @@ final class DictationWorkflow: ObservableObject {
 
         activeTranscriptionTask?.cancel()
 
-        let settings = settingsStore.settings
+        let settings = settingsProvider.currentSettings
 
         activeTranscriptionTask = Task { [weak self] in
             guard let self else { return }
@@ -421,7 +406,7 @@ final class DictationWorkflow: ObservableObject {
     }
 
     private func resolveCaptureRoute() -> (deviceID: AudioDeviceID?, routingState: InputRoutingState) {
-        let settings = settingsStore.settings
+        let settings = settingsProvider.currentSettings
         let resolution = audioInputDeviceService.resolve(
             preference: settings.audioInputPreference,
             preferredName: settings.preferredAudioInputName
@@ -458,7 +443,7 @@ final class DictationWorkflow: ObservableObject {
                 onOutcome?(.notification("Preferred microphone unavailable. Using System Default input."))
             }
         case (.preferredFallback(let previousUID), .preferredAvailable(let currentUID)) where previousUID == currentUID:
-            let selectedName = settingsStore.settings.preferredAudioInputName
+            let selectedName = settingsProvider.currentSettings.preferredAudioInputName
             let display = selectedName.isEmpty ? "preferred microphone" : selectedName
             onOutcome?(.notification("Preferred microphone reconnected. Using \(display)."))
         default:
@@ -481,65 +466,6 @@ final class DictationWorkflow: ObservableObject {
             latencyTracker.clear(sessionID: sessionID)
         }
         activeSessionID = nil
-    }
-
-    private func updateModelRuntimePreflightDescription() {
-        let bundledCLI = Bundle.main.resourceURL?
-            .appendingPathComponent("bin", isDirectory: true)
-            .appendingPathComponent("whisper-cli", isDirectory: false)
-
-        let cliStatus: String
-        if let bundledCLI, FileManager.default.isExecutableFile(atPath: bundledCLI.path) {
-            cliStatus = "Bundled whisper-cli: ready"
-        } else {
-            cliStatus = "Bundled whisper-cli: missing"
-        }
-
-        let modelStatus = bundledBaseModelURL() == nil ? "Bundled base model: missing" : "Bundled base model: ready"
-        snapshot.modelRuntimePreflightDescription = "\(cliStatus) • \(modelStatus)"
-    }
-
-    private func bundledBaseModelURL() -> URL? {
-        guard let resourceURL = Bundle.main.resourceURL else {
-            return nil
-        }
-
-        let candidates = [
-            resourceURL.appendingPathComponent("models/base/model.bin", isDirectory: false),
-            resourceURL.appendingPathComponent("models/base.bin", isDirectory: false),
-            resourceURL.appendingPathComponent("base.bin", isDirectory: false),
-        ]
-
-        return candidates.first(where: { FileManager.default.fileExists(atPath: $0.path) })
-    }
-
-    private func hasUsableWhisperExecutable() -> Bool {
-        if let bundledExecutable = Bundle.main.resourceURL?
-            .appendingPathComponent("bin", isDirectory: true)
-            .appendingPathComponent("whisper-cli", isDirectory: false),
-           FileManager.default.isExecutableFile(atPath: bundledExecutable.path) {
-            return true
-        }
-
-        let knownPaths = [
-            "/opt/homebrew/bin/whisper-cli",
-            "/usr/local/bin/whisper-cli",
-            "/usr/bin/whisper-cli",
-        ]
-
-        if knownPaths.contains(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
-            return true
-        }
-
-        let environmentPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
-        for pathEntry in environmentPath.split(separator: ":") {
-            let candidate = String(pathEntry) + "/whisper-cli"
-            if FileManager.default.isExecutableFile(atPath: candidate) {
-                return true
-            }
-        }
-
-        return false
     }
 
     private func mapTranscriptionWorkflowError(_ error: Error) -> AppWorkflowError {

--- a/the-dictator/the-dictator/Core/ModelManagerModule.swift
+++ b/the-dictator/the-dictator/Core/ModelManagerModule.swift
@@ -1,0 +1,430 @@
+import Combine
+import Foundation
+
+struct ModelManagerSnapshot: Equatable {
+    var availableModels: [ManagedModelDescriptor] = []
+    var installedModelIDs: Set<String> = []
+    var downloadStates: [String: ModelDownloadState] = [:]
+    var updateAvailableModelIDs: Set<String> = []
+    var statusMessage: String?
+    var catalogLastRefreshedAt: Date?
+    var catalogNextRetryAt: Date?
+    var isRefreshingCatalog: Bool = false
+    var isUsingFallbackCatalog: Bool = false
+    var installedRecordsByID: [String: InstalledModelRecord] = [:]
+}
+
+@MainActor
+final class ModelManagerModule: ObservableObject {
+    @Published private(set) var snapshot = ModelManagerSnapshot()
+
+    var onInventoryChanged: (() -> Void)?
+
+    private let settingsProvider: ModelManagerSettingsProviding
+    private let modelStoreService: ModelStoreService
+    private let modelCatalogService: ModelCatalogService
+    private let modelDownloadService: ModelDownloadService
+    private let modelIntegrityService: ModelIntegrityService
+
+    private var modelCatalogConsecutiveFailures: Int = 0
+    private var activeModelCatalogRefreshTask: Task<Void, Never>?
+
+    private static let fallbackModelCatalog: [ManagedModelDescriptor] = [
+        ManagedModelDescriptor(
+            id: "tiny",
+            level: .tiny,
+            displayName: "Fastest",
+            technicalName: "tiny",
+            diskBytes: 78_000_000,
+            estimatedRamBytes: 350_000_000,
+            downloadURL: nil,
+            sha256: "",
+            version: "fallback",
+            bundled: false,
+            minAppVersion: "0.0.0",
+            maxAppVersion: nil
+        ),
+        ManagedModelDescriptor(
+            id: "base",
+            level: .base,
+            displayName: "Balanced",
+            technicalName: "base",
+            diskBytes: 142_000_000,
+            estimatedRamBytes: 500_000_000,
+            downloadURL: nil,
+            sha256: "",
+            version: "fallback",
+            bundled: true,
+            minAppVersion: "0.0.0",
+            maxAppVersion: nil
+        ),
+        ManagedModelDescriptor(
+            id: "small",
+            level: .small,
+            displayName: "Higher Accuracy",
+            technicalName: "small",
+            diskBytes: 488_000_000,
+            estimatedRamBytes: 1_300_000_000,
+            downloadURL: nil,
+            sha256: "",
+            version: "fallback",
+            bundled: false,
+            minAppVersion: "0.0.0",
+            maxAppVersion: nil
+        ),
+        ManagedModelDescriptor(
+            id: "medium",
+            level: .medium,
+            displayName: "High Accuracy",
+            technicalName: "medium",
+            diskBytes: 1_530_000_000,
+            estimatedRamBytes: 3_500_000_000,
+            downloadURL: nil,
+            sha256: "",
+            version: "fallback",
+            bundled: false,
+            minAppVersion: "0.0.0",
+            maxAppVersion: nil
+        ),
+        ManagedModelDescriptor(
+            id: "large",
+            level: .large,
+            displayName: "Best Accuracy",
+            technicalName: "large",
+            diskBytes: 3_100_000_000,
+            estimatedRamBytes: 6_500_000_000,
+            downloadURL: nil,
+            sha256: "",
+            version: "fallback",
+            bundled: false,
+            minAppVersion: "0.0.0",
+            maxAppVersion: nil
+        ),
+    ]
+
+    init(
+        settingsProvider: ModelManagerSettingsProviding,
+        modelStoreService: ModelStoreService,
+        modelCatalogService: ModelCatalogService,
+        modelDownloadService: ModelDownloadService,
+        modelIntegrityService: ModelIntegrityService
+    ) {
+        self.settingsProvider = settingsProvider
+        self.modelStoreService = modelStoreService
+        self.modelCatalogService = modelCatalogService
+        self.modelDownloadService = modelDownloadService
+        self.modelIntegrityService = modelIntegrityService
+
+        self.modelDownloadService.onStateChange = { [weak self] modelID, state in
+            Task { @MainActor in
+                self?.snapshot.downloadStates[modelID] = state
+            }
+        }
+
+        registerBundledBaseModelIfAvailable()
+        refreshInstalledModels()
+        refreshModelCatalog()
+    }
+
+    func refreshModelCatalog(force: Bool = false) {
+        if activeModelCatalogRefreshTask != nil {
+            return
+        }
+
+        if !force, let nextRetryAt = snapshot.catalogNextRetryAt, Date() < nextRetryAt {
+            let remaining = max(Int(nextRetryAt.timeIntervalSinceNow.rounded()), 1)
+            snapshot.statusMessage = "Model catalog retry scheduled in \(remaining)s."
+            return
+        }
+
+        snapshot.isRefreshingCatalog = true
+        activeModelCatalogRefreshTask = Task { @MainActor in
+            defer {
+                activeModelCatalogRefreshTask = nil
+                snapshot.isRefreshingCatalog = false
+            }
+
+            do {
+                let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+                let manifest = try await modelCatalogService.fetchManifest()
+                let compatible = modelCatalogService.compatibleModels(from: manifest, appVersion: appVersion)
+                snapshot.availableModels = compatible.sorted { $0.diskBytes < $1.diskBytes }
+                snapshot.isUsingFallbackCatalog = false
+                modelCatalogConsecutiveFailures = 0
+                snapshot.catalogNextRetryAt = nil
+                snapshot.catalogLastRefreshedAt = Date()
+                snapshot.statusMessage = compatible.isEmpty ? "No compatible models available for this app version." : nil
+            } catch {
+                snapshot.availableModels = Self.fallbackModelCatalog
+                snapshot.isUsingFallbackCatalog = true
+                modelCatalogConsecutiveFailures += 1
+                let retryDelay = Self.catalogRetryDelaySeconds(failureCount: modelCatalogConsecutiveFailures)
+                snapshot.catalogNextRetryAt = Date().addingTimeInterval(retryDelay)
+                snapshot.statusMessage = "Unable to load online model catalog. Showing local fallback metadata."
+            }
+
+            refreshInstalledModels()
+        }
+    }
+
+    func refreshInstalledModels() {
+        let installedRecords = modelStoreService.allInstalled()
+        snapshot.installedModelIDs = Set(installedRecords.map(\.modelID))
+        snapshot.installedRecordsByID = Dictionary(uniqueKeysWithValues: installedRecords.map { ($0.modelID, $0) })
+
+        let updates = snapshot.availableModels.compactMap { descriptor -> String? in
+            guard let installed = snapshot.installedRecordsByID[descriptor.id] else {
+                return nil
+            }
+            if snapshot.isUsingFallbackCatalog {
+                return nil
+            }
+            return installed.version != descriptor.version ? descriptor.id : nil
+        }
+        snapshot.updateAvailableModelIDs = Set(updates)
+        onInventoryChanged?()
+    }
+
+    func isModelInstalled(_ modelID: String) -> Bool {
+        snapshot.installedModelIDs.contains(modelID)
+    }
+
+    func isModelUpdateAvailable(_ modelID: String) -> Bool {
+        snapshot.updateAvailableModelIDs.contains(modelID)
+    }
+
+    func selectModel(id: String) {
+        settingsProvider.update { settings in
+            settings.selectedModelID = id
+            settings.useCustomModelPath = false
+        }
+    }
+
+    func performRuntimeRecoveryAction() {
+        let previousModelID = settingsProvider.currentSettings.selectedModelID
+        guard let recoveryModelID = runtimeRecoveryTargetModelID else {
+            return
+        }
+
+        AppLogger.info(
+            AppLogger.settings,
+            "Runtime recovery action: switching model from \(previousModelID) to \(recoveryModelID)."
+        )
+
+        selectModel(id: recoveryModelID)
+        if recoveryModelID == "base" {
+            snapshot.statusMessage = "Switched to bundled base model."
+        } else {
+            snapshot.statusMessage = "Switched to installed model: \(recoveryModelID)."
+        }
+    }
+
+    func downloadModel(id: String) {
+        guard let descriptor = snapshot.availableModels.first(where: { $0.id == id }) else {
+            snapshot.statusMessage = "Unknown model selection: \(id)."
+            return
+        }
+
+        Task { @MainActor in
+            snapshot.downloadStates[id] = .downloading(progress: 0)
+
+            do {
+                let tempURL = try await modelDownloadService.startDownload(descriptor)
+                let expectedHash = descriptor.sha256.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !expectedHash.isEmpty {
+                    try modelIntegrityService.verifySHA256(fileURL: tempURL, expectedHex: expectedHash)
+                }
+                _ = try modelStoreService.install(tempFileURL: tempURL, descriptor: descriptor)
+                refreshInstalledModels()
+                snapshot.downloadStates[id] = .completed(tempFilePath: tempURL.path)
+                snapshot.statusMessage = "Installed \(descriptor.displayName) (\(descriptor.technicalName))."
+            } catch {
+                if let downloadError = error as? ModelDownloadError, case .cancelled = downloadError {
+                    snapshot.downloadStates[id] = .idle
+                    snapshot.statusMessage = "Download cancelled for \(descriptor.displayName)."
+                    return
+                }
+
+                let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+                let visibleMessage = message.isEmpty ? "Unknown error" : message
+                snapshot.downloadStates[id] = .failed(message: visibleMessage)
+                snapshot.statusMessage = "Failed to install \(descriptor.displayName): \(visibleMessage)"
+                AppLogger.error(AppLogger.settings, "Model install failed for \(descriptor.id): \(visibleMessage)")
+            }
+        }
+    }
+
+    func cancelModelDownload(id: String) {
+        modelDownloadService.cancelDownload(modelID: id)
+        snapshot.downloadStates[id] = .idle
+    }
+
+    func deleteModel(id: String) {
+        guard canDeleteModel(id) else {
+            snapshot.statusMessage = "\(id) is bundled with the app and cannot be deleted."
+            return
+        }
+
+        do {
+            try modelStoreService.delete(modelID: id)
+            refreshInstalledModels()
+            snapshot.downloadStates[id] = .idle
+            snapshot.statusMessage = "Deleted model \(id)."
+        } catch {
+            snapshot.statusMessage = "Failed to delete model \(id): \(error.localizedDescription)"
+        }
+    }
+
+    func modelLabel(for descriptor: ManagedModelDescriptor) -> String {
+        "\(descriptor.displayName) (\(descriptor.technicalName))"
+    }
+
+    func modelResourceHint(for descriptor: ManagedModelDescriptor) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useMB, .useGB]
+        formatter.countStyle = .file
+        let disk = formatter.string(fromByteCount: descriptor.diskBytes)
+        let ram = formatter.string(fromByteCount: descriptor.estimatedRamBytes)
+        return "Disk: \(disk) • Est. RAM: \(ram)"
+    }
+
+    func modelVersionHint(for descriptor: ManagedModelDescriptor) -> String {
+        let available = descriptor.version
+        if let installed = snapshot.installedRecordsByID[descriptor.id]?.version {
+            return installed == available ? "Version: \(available)" : "Installed: \(installed) • Available: \(available)"
+        }
+        return "Available version: \(available)"
+    }
+
+    func isBundledModel(_ modelID: String) -> Bool {
+        snapshot.availableModels.first(where: { $0.id == modelID })?.bundled ?? false
+    }
+
+    func canDeleteModel(_ modelID: String) -> Bool {
+        isModelInstalled(modelID) && !isBundledModel(modelID)
+    }
+
+    var onboardingHint: String? {
+        if isModelInstalled("base") {
+            return "Balanced (base) is bundled and ready for offline dictation."
+        }
+
+        return "No bundled base model detected. Download a model to start dictation."
+    }
+
+    var runtimeRecoveryActionTitle: String? {
+        guard let recoveryModelID = runtimeRecoveryTargetModelID else {
+            return nil
+        }
+
+        if recoveryModelID == "base" {
+            return "Use bundled base model"
+        }
+
+        return "Use installed model (\(recoveryModelID))"
+    }
+
+    func modelStatus(for modelID: String) -> String {
+        if case .downloading(let progress) = snapshot.downloadStates[modelID] {
+            return "Downloading \(Int(progress * 100))%"
+        }
+
+        if case .failed = snapshot.downloadStates[modelID] {
+            return "Failed"
+        }
+
+        let settings = settingsProvider.currentSettings
+        if settings.selectedModelID == modelID && !settings.useCustomModelPath {
+            if isModelInstalled(modelID) {
+                return isModelUpdateAvailable(modelID) ? "Active • Update available" : "Active"
+            }
+            return "Selected (not installed)"
+        }
+
+        if isModelInstalled(modelID) {
+            if isBundledModel(modelID) {
+                return isModelUpdateAvailable(modelID) ? "Bundled • Update available" : "Bundled"
+            }
+            return isModelUpdateAvailable(modelID) ? "Installed • Update available" : "Installed"
+        }
+
+        return "Not installed"
+    }
+
+    func catalogRefreshDescription(relativeTo referenceDate: Date = Date()) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+
+        let refreshedText: String
+        if let refreshedAt = snapshot.catalogLastRefreshedAt {
+            refreshedText = "Last refresh \(formatter.localizedString(for: refreshedAt, relativeTo: referenceDate))"
+        } else {
+            refreshedText = "Catalog not refreshed yet"
+        }
+
+        if let retryAt = snapshot.catalogNextRetryAt, referenceDate < retryAt {
+            return "\(refreshedText) • Retry \(formatter.localizedString(for: retryAt, relativeTo: referenceDate))"
+        }
+
+        return refreshedText
+    }
+
+    private var runtimeRecoveryTargetModelID: String? {
+        let settings = settingsProvider.currentSettings
+        guard !settings.useCustomModelPath else {
+            return nil
+        }
+
+        let selected = settings.selectedModelID
+        guard !isModelInstalled(selected) else {
+            return nil
+        }
+
+        if selected != "base", isModelInstalled("base") {
+            return "base"
+        }
+
+        if let preferredInstalled = snapshot.availableModels
+            .map(\.id)
+            .first(where: { $0 != selected && isModelInstalled($0) }) {
+            return preferredInstalled
+        }
+
+        return snapshot.installedModelIDs
+            .sorted()
+            .first(where: { $0 != selected })
+    }
+
+    private func registerBundledBaseModelIfAvailable() {
+        guard let bundledModelURL = bundledBaseModelURL() else {
+            return
+        }
+
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        do {
+            try modelStoreService.registerBundledModel(modelID: "base", version: appVersion, fileURL: bundledModelURL)
+        } catch {
+            AppLogger.error(AppLogger.settings, "Failed to register bundled base model: \(error.localizedDescription)")
+        }
+    }
+
+    private func bundledBaseModelURL() -> URL? {
+        guard let resourceURL = Bundle.main.resourceURL else {
+            return nil
+        }
+
+        let candidates = [
+            resourceURL.appendingPathComponent("models/base/model.bin", isDirectory: false),
+            resourceURL.appendingPathComponent("models/base.bin", isDirectory: false),
+            resourceURL.appendingPathComponent("base.bin", isDirectory: false),
+        ]
+
+        return candidates.first(where: { FileManager.default.fileExists(atPath: $0.path) })
+    }
+
+    private static func catalogRetryDelaySeconds(failureCount: Int) -> TimeInterval {
+        let schedule: [TimeInterval] = [5, 15, 30, 60, 120, 300]
+        let index = min(max(failureCount - 1, 0), schedule.count - 1)
+        return schedule[index]
+    }
+}

--- a/the-dictator/the-dictator/Services/RuntimeReadinessService.swift
+++ b/the-dictator/the-dictator/Services/RuntimeReadinessService.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+protocol DictationRuntimeReadinessProviding {
+    func modelRuntimePreflightDescription() -> String
+    func runtimeIssue(for settings: AppSettings) -> String?
+}
+
+final class RuntimeReadinessService: DictationRuntimeReadinessProviding {
+    private let modelStoreService: ModelStoreService
+    private let fileExists: (String) -> Bool
+    private let executableExists: (String) -> Bool
+    private let pathProvider: () -> String
+
+    init(
+        modelStoreService: ModelStoreService,
+        fileExists: @escaping (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        executableExists: @escaping (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) },
+        pathProvider: @escaping () -> String = { ProcessInfo.processInfo.environment["PATH"] ?? "" }
+    ) {
+        self.modelStoreService = modelStoreService
+        self.fileExists = fileExists
+        self.executableExists = executableExists
+        self.pathProvider = pathProvider
+    }
+
+    func modelRuntimePreflightDescription() -> String {
+        let bundledCLI = Bundle.main.resourceURL?
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("whisper-cli", isDirectory: false)
+
+        let cliStatus: String
+        if let bundledCLI, FileManager.default.isExecutableFile(atPath: bundledCLI.path) {
+            cliStatus = "Bundled whisper-cli: ready"
+        } else {
+            cliStatus = "Bundled whisper-cli: missing"
+        }
+
+        let modelStatus = bundledBaseModelURL() == nil ? "Bundled base model: missing" : "Bundled base model: ready"
+        return "\(cliStatus) • \(modelStatus)"
+    }
+
+    func runtimeIssue(for settings: AppSettings) -> String? {
+        if !hasUsableWhisperExecutable() {
+            return "Transcription engine is unavailable. Reinstall the app or add whisper-cli to PATH."
+        }
+
+        if settings.useCustomModelPath {
+            if settings.customModelPath.isEmpty || !fileExists(settings.customModelPath) {
+                return "Custom model file is unavailable. Choose a valid model file in Settings → Transcription."
+            }
+            return nil
+        }
+
+        if modelStoreService.localPath(for: settings.selectedModelID) == nil {
+            return "Selected model \(settings.selectedModelID) is not installed. Open Settings → Transcription and download it in Model Manager."
+        }
+
+        return nil
+    }
+
+    private func bundledBaseModelURL() -> URL? {
+        guard let resourceURL = Bundle.main.resourceURL else {
+            return nil
+        }
+
+        let candidates = [
+            resourceURL.appendingPathComponent("models/base/model.bin", isDirectory: false),
+            resourceURL.appendingPathComponent("models/base.bin", isDirectory: false),
+            resourceURL.appendingPathComponent("base.bin", isDirectory: false),
+        ]
+
+        return candidates.first(where: { fileExists($0.path) })
+    }
+
+    private func hasUsableWhisperExecutable() -> Bool {
+        if let bundledExecutable = Bundle.main.resourceURL?
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("whisper-cli", isDirectory: false),
+           executableExists(bundledExecutable.path) {
+            return true
+        }
+
+        let knownPaths = [
+            "/opt/homebrew/bin/whisper-cli",
+            "/usr/local/bin/whisper-cli",
+            "/usr/bin/whisper-cli",
+        ]
+
+        if knownPaths.contains(where: { executableExists($0) }) {
+            return true
+        }
+
+        let environmentPath = pathProvider()
+        for pathEntry in environmentPath.split(separator: ":") {
+            let candidate = String(pathEntry) + "/whisper-cli"
+            if executableExists(candidate) {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/the-dictator/the-dictator/Services/SettingsStore.swift
+++ b/the-dictator/the-dictator/Services/SettingsStore.swift
@@ -164,3 +164,9 @@ final class SettingsStore: ObservableObject {
         return trimmed.isEmpty ? fallback : trimmed
     }
 }
+
+extension SettingsStore: ModelManagerSettingsProviding {
+    var currentSettings: AppSettings {
+        settings
+    }
+}


### PR DESCRIPTION
## Summary
- extract a dedicated ModelManagerModule and thin AppModel into a composition adapter
- introduce narrow settings/runtime-readiness seams for workflow and model management
- move runtime readiness checks behind RuntimeReadinessService
- add seam-focused regression tests and CI workflow

## Validation
- scripts/test-architecture-seams.sh
- xcodebuild -project the-dictator/the-dictator.xcodeproj -scheme the-dictator -configuration Debug -derivedDataPath /tmp/the-dictator-dd4 build

## Notes
- behavior locks preserved (hotkey threshold, notifications, model fallback/retry/recovery order, settings-window activation behavior).