### PR TITLE
Improve audio routing resilience and add optional release diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,19 @@ Download release artifacts from GitHub Releases:
 ```bash
 scripts/build-unsigned-release-artifacts.sh --version 1.0.0
 ```
+
+## Optional diagnostics in Release test builds
+
+To enable audio routing/hotkey diagnostics without enabling full `DEBUG` behavior,
+compile with `DIAGNOSTIC_AUDIO_ROUTING`:
+
+```bash
+xcodebuild \
+  -scheme the-dictator \
+  -configuration Release \
+  -project the-dictator/the-dictator.xcodeproj \
+  OTHER_SWIFT_FLAGS='$(inherited) -DDIAGNOSTIC_AUDIO_ROUTING' \
+  build
+```
+
+Diagnostic lines are prefixed with `[diag.audio]`.

--- a/the-dictator/the-dictator/Core/AppModel.swift
+++ b/the-dictator/the-dictator/Core/AppModel.swift
@@ -211,13 +211,17 @@ final class AppModel: ObservableObject {
     private func setupHotkeyCallbacks() {
         hotkeyService?.onKeyDown = { [weak self] in
             Task { @MainActor in
-                await self?.dictationWorkflow.startDictation()
+                guard let self else { return }
+                AppLogger.diagnostic(AppLogger.workflow, "Hotkey callback: keyDown dispatched on MainActor")
+                await self.dictationWorkflow.startDictation()
             }
         }
 
         hotkeyService?.onKeyUp = { [weak self] in
             Task { @MainActor in
-                self?.dictationWorkflow.finishDictationHold()
+                guard let self else { return }
+                AppLogger.diagnostic(AppLogger.workflow, "Hotkey callback: keyUp dispatched on MainActor")
+                self.dictationWorkflow.finishDictationHold()
             }
         }
     }

--- a/the-dictator/the-dictator/Core/AppWorkflow.swift
+++ b/the-dictator/the-dictator/Core/AppWorkflow.swift
@@ -197,14 +197,20 @@ final class DictationWorkflow: ObservableObject {
     }
 
     func startDictation() async {
+        AppLogger.diagnostic(AppLogger.workflow, "startDictation requested. state=\(String(describing: snapshot.state)) activeSessionID=\(activeSessionID?.uuidString ?? "nil")")
+
         guard snapshot.state == .idle, activeSessionID == nil else {
+            AppLogger.diagnostic(AppLogger.workflow, "startDictation ignored because workflow is not idle")
             return
         }
 
         if let runtimeIssue = snapshot.runtimeIssue {
+            AppLogger.diagnostic(AppLogger.workflow, "startDictation blocked by runtime issue: \(runtimeIssue)")
             onOutcome?(.notification(runtimeIssue))
             return
         }
+
+        logAudioDeviceSnapshot(context: "pre-capture")
 
         let hasPermission = await permissionsService.requestMicrophonePermissionForRecording(notificationService: notificationService)
         onOutcome?(.permissionStatusMayHaveChanged)
@@ -218,7 +224,17 @@ final class DictationWorkflow: ObservableObject {
         let captureRoute = resolveCaptureRoute()
 
         do {
-            try audioCaptureService.startCapture(deviceID: captureRoute.deviceID)
+            do {
+                try audioCaptureService.startCapture(deviceID: captureRoute.deviceID)
+            } catch {
+                if shouldRetryWithSystemDefault(for: error, attemptedDeviceID: captureRoute.deviceID) {
+                    AppLogger.info(AppLogger.app, "Retrying audio capture with system-selected default input device")
+                    try audioCaptureService.startCapture(deviceID: nil)
+                } else {
+                    throw error
+                }
+            }
+
             recordingStartedAt = Date()
             activeSessionID = UUID()
             apply(.hotkeyDown(permissionsOK: true))
@@ -233,7 +249,10 @@ final class DictationWorkflow: ObservableObject {
     }
 
     func finishDictationHold() {
+        AppLogger.diagnostic(AppLogger.workflow, "finishDictationHold requested. state=\(String(describing: snapshot.state)) activeSessionID=\(activeSessionID?.uuidString ?? "nil")")
+
         guard snapshot.state == .recording, let sessionID = activeSessionID else {
+            AppLogger.diagnostic(AppLogger.workflow, "finishDictationHold ignored because app is not recording")
             return
         }
 
@@ -405,6 +424,22 @@ final class DictationWorkflow: ObservableObject {
         }
     }
 
+    private func logAudioDeviceSnapshot(context: String) {
+        guard AppLogger.diagnosticAudioRoutingEnabled else {
+            return
+        }
+
+        let listedDevices = audioInputDeviceService.devices
+            .map { device in
+                let defaultMarker = device.isSystemDefault ? "*" : ""
+                let availability = device.isAvailable ? "up" : "down"
+                return "\(defaultMarker)\(device.name){\(availability)}"
+            }
+            .joined(separator: ", ")
+
+        AppLogger.diagnostic(AppLogger.app, "Audio devices [\(context)]: \(listedDevices)")
+    }
+
     private func resolveCaptureRoute() -> (deviceID: AudioDeviceID?, routingState: InputRoutingState) {
         let settings = settingsProvider.currentSettings
         let resolution = audioInputDeviceService.resolve(
@@ -414,9 +449,8 @@ final class DictationWorkflow: ObservableObject {
 
         switch resolution {
         case .systemDefault(defaultDevice: let defaultDevice):
-            let deviceID = defaultDevice.flatMap { audioInputDeviceService.deviceID(forUID: $0.uid) }
             AppLogger.info(AppLogger.app, "Audio input route: system default (\(defaultDevice?.name ?? "unknown"))")
-            return (deviceID, .systemDefault)
+            return (nil, .systemDefault)
 
         case .specificAvailable(device: let device):
             let deviceID = audioInputDeviceService.deviceID(forUID: device.uid)
@@ -424,14 +458,25 @@ final class DictationWorkflow: ObservableObject {
             return (deviceID, .preferredAvailable(uid: device.uid))
 
         case .specificUnavailable(selectedUID: let selectedUID, selectedName: let selectedName, fallbackDevice: let fallbackDevice):
-            let fallbackID = fallbackDevice.flatMap { audioInputDeviceService.deviceID(forUID: $0.uid) }
             let preferredDisplay = selectedName.isEmpty ? selectedUID : selectedName
             AppLogger.info(
                 AppLogger.app,
                 "Audio input route fallback: preferred \(preferredDisplay) uid=\(selectedUID) unavailable, using system default \(fallbackDevice?.name ?? "unknown")"
             )
-            return (fallbackID, .preferredFallback(uid: selectedUID))
+            return (nil, .preferredFallback(uid: selectedUID))
         }
+    }
+
+    private func shouldRetryWithSystemDefault(for error: Error, attemptedDeviceID: AudioDeviceID?) -> Bool {
+        guard attemptedDeviceID != nil else {
+            return false
+        }
+
+        guard case AudioCaptureError.failedToSelectInputDevice = error else {
+            return false
+        }
+
+        return true
     }
 
     private func updateRouteNotifications(for routingState: InputRoutingState) {

--- a/the-dictator/the-dictator/Services/AppLogger.swift
+++ b/the-dictator/the-dictator/Services/AppLogger.swift
@@ -9,9 +9,23 @@ enum AppLogger {
     static let settings = Logger(subsystem: subsystem, category: "Settings")
     static let notifications = Logger(subsystem: subsystem, category: "Notifications")
 
+    static var diagnosticAudioRoutingEnabled: Bool {
+#if DEBUG || DIAGNOSTIC_AUDIO_ROUTING
+        true
+#else
+        false
+#endif
+    }
+
     static func debug(_ logger: Logger, _ message: String) {
 #if DEBUG
         logger.debug("\(message, privacy: .public)")
+#endif
+    }
+
+    static func diagnostic(_ logger: Logger, _ message: String) {
+#if DEBUG || DIAGNOSTIC_AUDIO_ROUTING
+        logger.info("[diag.audio] \(message, privacy: .public)")
 #endif
     }
 

--- a/the-dictator/the-dictator/Services/AudioCaptureService.swift
+++ b/the-dictator/the-dictator/Services/AudioCaptureService.swift
@@ -22,10 +22,27 @@ enum AudioCaptureError: LocalizedError {
         case .fileWriteFailed:
             return "Failed to write captured audio."
         case .failedToSelectInputDevice(let status):
-            return "Failed to select microphone device (status: \(status))."
+            return "Failed to select microphone device (status: \(status), fourCC: \(Self.fourCCString(for: status)))."
         case .audioUnitUnavailable:
             return "Failed to access audio input unit."
         }
+    }
+
+    private static func fourCCString(for status: OSStatus) -> String {
+        let value = UInt32(bitPattern: status)
+        let scalars: [UnicodeScalar] = [
+            UnicodeScalar((value >> 24) & 0xFF),
+            UnicodeScalar((value >> 16) & 0xFF),
+            UnicodeScalar((value >> 8) & 0xFF),
+            UnicodeScalar(value & 0xFF),
+        ].compactMap { $0 }
+
+        if scalars.count == 4,
+           scalars.allSatisfy({ (32...126).contains(Int($0.value)) }) {
+            return String(String.UnicodeScalarView(scalars))
+        }
+
+        return "0x\(String(value, radix: 16, uppercase: true))"
     }
 }
 

--- a/the-dictator/the-dictator/Services/HotkeyService.swift
+++ b/the-dictator/the-dictator/Services/HotkeyService.swift
@@ -122,6 +122,12 @@ final class HotkeyService {
 
         let eventKind = GetEventKind(eventRef)
 
+        if eventKind == UInt32(kEventHotKeyPressed) {
+            AppLogger.diagnostic(AppLogger.workflow, "Hotkey event received: keyDown")
+        } else if eventKind == UInt32(kEventHotKeyReleased) {
+            AppLogger.diagnostic(AppLogger.workflow, "Hotkey event received: keyUp")
+        }
+
         DispatchQueue.main.async {
             if eventKind == UInt32(kEventHotKeyPressed) {
                 service.onKeyDown?()


### PR DESCRIPTION
## Summary
- fix intermittent microphone startup failures by avoiding explicit device binding when using system default input
- add a retry path that falls back to system-selected default input when specific-device selection fails
- introduce toggleable audio/hotkey diagnostics for release test builds via `DIAGNOSTIC_AUDIO_ROUTING`

## Key changes
- `DictationWorkflow`
  - system-default and fallback routes now pass `nil` device ID to let AVAudioEngine select the active default input
  - on `failedToSelectInputDevice`, retry capture once with system-selected default input
  - added diagnostic workflow and pre-capture device snapshot logging through a gated diagnostic logger
- `AudioCaptureService`
  - improved device-selection error text to include both OSStatus and fourCC decoding
- `AppLogger`
  - added `diagnostic(...)` and `diagnosticAudioRoutingEnabled` gated by `DEBUG || DIAGNOSTIC_AUDIO_ROUTING`
- `HotkeyService` and `AppModel`
  - added diagnostic tracing for hotkey event receipt and MainActor callback dispatch
- `README.md`
  - documented how to build a Release test binary with `-DDIAGNOSTIC_AUDIO_ROUTING`

## Risks / notes
- diagnostic logs are intentionally higher volume when enabled
- release behavior is unchanged unless `DIAGNOSTIC_AUDIO_ROUTING` is explicitly set
- route-selection behavior now defers to CoreAudio defaults for system-default/fallback cases

## Testing
- Not run (by design in this workflow)
